### PR TITLE
Discard notion of multiple pools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ name = "scheduling"
 harness = false
 
 [dependencies]
-arrayvec = "0.7"
 bitflags = "1"
 futures-intrusive = "0.4"
 futures-task = "0.3"

--- a/deny.toml
+++ b/deny.toml
@@ -13,16 +13,15 @@ allow = [
 [bans]
 multiple-versions = "deny"
 skip = [
-    # like everything
-    { name = "cfg-if", version = "0.1.10" },
-    # dev-deps
-    { name = "itertools", version = "0.9" },
+    # csv via criterion
+    { name = "itoa", version = "0.4.8" },
 ]
 
 [advisories]
 vulnerability = "deny"
 unmaintained = "deny"
 ignore = [
+    "RUSTSEC-2021-0127" # serde-cbor from criterion
 ]
 
 [sources]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,40 +1,14 @@
-use crate::MAX_POOLS;
 use std::{error::Error, fmt};
 
 /// Errors encountered when creating a [`Switchyard`](crate::Switchyard).
 #[derive(Debug)]
 pub enum SwitchyardCreationError {
-    InvalidPoolIndex {
-        thread_idx: usize,
-        pool_idx: u8,
-        total_pools: u8,
-    },
-    TooManyPools {
-        pools_requested: u8,
-    },
-    InvalidAffinity {
-        affinity: usize,
-        total_threads: usize,
-    },
+    InvalidAffinity { affinity: usize, total_threads: usize },
 }
 
 impl fmt::Display for SwitchyardCreationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            Self::InvalidPoolIndex {
-                thread_idx,
-                pool_idx,
-                total_pools,
-            } => write!(
-                f,
-                "Thread index {} requested job pool {} but there are only {} pools",
-                thread_idx, pool_idx, total_pools
-            ),
-            Self::TooManyPools { pools_requested } => write!(
-                f,
-                "Requested {} pools which is greater than the max {}",
-                pools_requested, MAX_POOLS
-            ),
             Self::InvalidAffinity {
                 affinity,
                 total_threads,

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -1,7 +1,5 @@
 //! Helper functions for creating iterators of [`ThreadAllocationOutput`] for spawning on the [`Switchyard`](crate::Switchyard).
 
-use crate::Pool;
-
 /// Information about threads on the system
 // TODO: Detect and expose big.LITTLE
 #[derive(Debug, Clone, PartialEq)]
@@ -19,8 +17,6 @@ pub struct ThreadAllocationOutput {
     pub name: Option<String>,
     /// Identifier.
     pub ident: usize,
-    /// Job pool index that the thread services.
-    pub pool: Pool,
     /// Size of spawned thread's stack. Will use system default if `None`.
     pub stack_size: Option<usize>,
     /// Core index to pin thread to. If a platform doesn't support affinity, will have
@@ -36,38 +32,34 @@ pub fn thread_info() -> ThreadAllocationInput {
     }
 }
 
-/// A single thread, single pool thread configuration.
+/// A single thread configuration.
 ///
-/// - Creates a single pool of jobs with index 0.
 /// - Creates a single thread.
-pub fn single_pool_single_thread(
+pub fn single_thread(
     thread_name: Option<String>,
     affinity: Option<usize>,
 ) -> impl Iterator<Item = ThreadAllocationOutput> {
     std::iter::once(ThreadAllocationOutput {
         name: thread_name,
         ident: 0,
-        pool: 0,
         stack_size: None,
         affinity,
     })
 }
 
-/// A single thread per core, single pool thread configuration.
+/// A single thread per core configuration.
 ///
-/// - Creates a single pool of jobs with index 0.
 /// - One thread per logical core.
 /// - Each thread assigned to a different core.
 ///
 /// `input` is the result of calling [`thread_info`].
-pub fn single_pool_one_to_one<'a>(
+pub fn one_to_one<'a>(
     input: ThreadAllocationInput,
     thread_name: Option<&'a str>,
 ) -> impl Iterator<Item = ThreadAllocationOutput> + 'a {
     (0..input.logical).map(move |idx| ThreadAllocationOutput {
         name: thread_name.map(ToOwned::to_owned),
         ident: idx,
-        pool: 0,
         stack_size: None,
         affinity: Some(idx),
     })
@@ -75,69 +67,17 @@ pub fn single_pool_one_to_one<'a>(
 
 /// A two thread per core, single pool thread configuration.
 ///
-/// - Creates a single pool of jobs with index 0.
 /// - Two threads per logical core.
 /// - Each set of two threads assigned to a different core.
 ///
 /// `input` is the result of calling [`thread_info`].
-pub fn single_pool_two_to_one<'a>(
+pub fn two_to_one<'a>(
     input: ThreadAllocationInput,
     thread_name: Option<&'a str>,
 ) -> impl Iterator<Item = ThreadAllocationOutput> + 'a {
     (0..(input.logical * 2)).map(move |idx| ThreadAllocationOutput {
         name: thread_name.map(ToOwned::to_owned),
         ident: idx,
-        pool: 0,
-        stack_size: None,
-        affinity: Some(idx / 2),
-    })
-}
-
-/// A one thread per core, two pool thread configuration.
-///
-/// - Creates two pools with indices 0 and 1.
-/// - One thread per logical core.
-/// - Each thread assigned to a different core.
-/// - Threads get assigned alternating pools:
-///   - Thread 0 -> Pool 0
-///   - Thread 1 -> Pool 1
-///   - Thread 2 -> Pool 0
-///   - Thread 3 -> Pool 1
-///
-/// `input` is the result of calling [`thread_info`].
-pub fn double_pool_one_to_one<'a>(
-    input: ThreadAllocationInput,
-    thread_name: Option<&'a str>,
-) -> impl Iterator<Item = ThreadAllocationOutput> + 'a {
-    (0..input.logical).map(move |idx| ThreadAllocationOutput {
-        name: thread_name.map(ToOwned::to_owned),
-        ident: idx,
-        pool: (idx % 2) as u8,
-        stack_size: None,
-        affinity: Some(idx),
-    })
-}
-
-/// A two thread per core, two pool thread configuration.
-///
-/// - Creates two pools with indices 0 and 1.
-/// - Two threads per logical core.
-/// - Each set of two threads assigned to a different core.
-/// - Threads get assigned alternating pools:
-///   - Thread 0 (Core 0) -> Pool 0
-///   - Thread 1 (Core 0) -> Pool 1
-///   - Thread 2 (Core 1) -> Pool 0
-///   - Thread 3 (Core 1) -> Pool 1
-///
-/// `input` is the result of calling [`thread_info`].
-pub fn double_pool_two_to_one<'a>(
-    input: ThreadAllocationInput,
-    thread_name: Option<&'a str>,
-) -> impl Iterator<Item = ThreadAllocationOutput> + 'a {
-    (0..(input.logical * 2)).map(move |idx| ThreadAllocationOutput {
-        name: thread_name.map(ToOwned::to_owned),
-        ident: idx,
-        pool: (idx % 2) as u8,
         stack_size: None,
         affinity: Some(idx / 2),
     })

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -39,7 +39,7 @@ where
             crate::affinity::set_thread_affinity([affin]).unwrap();
         }
 
-        let queue: &Queue<TD> = &shared.queues[thread_info.pool as usize];
+        let queue: &Queue<TD> = &shared.queue;
 
         loop {
             // Always grab global -> local
@@ -125,7 +125,6 @@ where
                             Arc::clone(&shared),
                             Arc::clone(&thread_queue),
                             fut,
-                            thread_info.pool,
                             queue_priority,
                             queue_local_index,
                         );

--- a/tests/interface.rs
+++ b/tests/interface.rs
@@ -1,46 +1,16 @@
-use switchyard::{threads::single_pool_single_thread, Switchyard, SwitchyardCreationError, MAX_POOLS};
-
-#[test]
-fn too_few_pools() {
-    let result = Switchyard::new(0, single_pool_single_thread(None, None), || ());
-    assert!(matches!(
-        result,
-        Err(SwitchyardCreationError::InvalidPoolIndex {
-            thread_idx: 0,
-            pool_idx: 0,
-            total_pools: 0
-        })
-    ));
-}
-
-#[test]
-fn too_many_pools() {
-    const POOLS: u8 = MAX_POOLS + 1;
-    let result = Switchyard::new(POOLS, single_pool_single_thread(None, None), || ());
-    assert!(matches!(
-        result,
-        Err(SwitchyardCreationError::TooManyPools { pools_requested: POOLS })
-    ));
-}
-
-#[test]
-#[should_panic]
-fn invalid_pool_spawn() {
-    let yard = Switchyard::new(1, single_pool_single_thread(None, None), || ()).unwrap();
-    yard.spawn(1, 0, async move {});
-}
+use switchyard::{threads::single_thread, Switchyard};
 
 #[test]
 #[should_panic]
 fn spawn_finished() {
-    let mut yard = Switchyard::new(1, single_pool_single_thread(None, None), || ()).unwrap();
+    let mut yard = Switchyard::new(single_thread(None, None), || ()).unwrap();
     yard.finish();
 
-    yard.spawn(0, 0, async move {});
+    yard.spawn(0, async move {});
 }
 
 #[test]
 #[should_panic]
 fn insane_affinity() {
-    let _yard = Switchyard::new(1, single_pool_single_thread(None, Some(usize::MAX)), || ()).unwrap();
+    let _yard = Switchyard::new(single_thread(None, Some(usize::MAX)), || ()).unwrap();
 }

--- a/tests/panic.rs
+++ b/tests/panic.rs
@@ -1,11 +1,11 @@
-use switchyard::{threads::single_pool_single_thread, Switchyard};
+use switchyard::{threads::single_thread, Switchyard};
 
 #[test]
 #[should_panic]
 fn panicking_future() {
-    let yard = Switchyard::new(1, single_pool_single_thread(None, None), || ()).unwrap();
+    let yard = Switchyard::new(single_thread(None, None), || ()).unwrap();
 
-    let handle = yard.spawn(0, 0, async move {
+    let handle = yard.spawn(0, async move {
         panic!("whoops!");
     });
 
@@ -15,9 +15,9 @@ fn panicking_future() {
 #[test]
 #[should_panic]
 fn panicking_function() {
-    let yard = Switchyard::new(1, single_pool_single_thread(None, None), || ()).unwrap();
+    let yard = Switchyard::new(single_thread(None, None), || ()).unwrap();
 
-    let handle = yard.spawn_local(0, 0, |_| {
+    let handle = yard.spawn_local(0, |_| {
         panic!("whoops!");
         #[allow(unreachable_code)]
         async move {}
@@ -29,25 +29,25 @@ fn panicking_function() {
 #[test]
 #[should_panic]
 fn panicking_local_future() {
-    let yard = Switchyard::new(1, single_pool_single_thread(None, None), || ()).unwrap();
+    let yard = Switchyard::new(single_thread(None, None), || ()).unwrap();
 
-    let handle = yard.spawn_local(0, 0, |_| async move { panic!("whoops!") });
+    let handle = yard.spawn_local(0, |_| async move { panic!("whoops!") });
 
     futures_executor::block_on(handle);
 }
 
 #[test]
 fn continue_from_panicking_future() {
-    let yard = Switchyard::new(1, single_pool_single_thread(None, None), || ()).unwrap();
+    let yard = Switchyard::new(single_thread(None, None), || ()).unwrap();
 
     // ignore handle, it'll panic
-    yard.spawn(0, 0, async move {
+    yard.spawn(0, async move {
         panic!("whoops!");
     });
 
     futures_executor::block_on(yard.wait_for_idle());
 
-    let handle = yard.spawn(0, 0, async move { 1 });
+    let handle = yard.spawn(0, async move { 1 });
 
     assert_eq!(futures_executor::block_on(handle), 1);
 }

--- a/tests/threads.rs
+++ b/tests/threads.rs
@@ -1,16 +1,14 @@
 use futures_executor::block_on;
 use switchyard::{
-    threads::{single_pool_one_to_one, thread_info},
+    threads::{one_to_one, thread_info},
     Switchyard,
 };
 
 #[test]
 fn ten_thousand() {
-    let yard = Switchyard::new(1, single_pool_one_to_one(thread_info(), None), || ()).unwrap();
+    let yard = Switchyard::new(one_to_one(thread_info(), None), || ()).unwrap();
 
-    let handles: Vec<_> = (0..10_000)
-        .map(|idx| yard.spawn(0, 0, async move { idx * 2 }))
-        .collect();
+    let handles: Vec<_> = (0..10_000).map(|idx| yard.spawn(0, async move { idx * 2 })).collect();
 
     block_on(async {
         for (idx, handle) in handles.into_iter().enumerate() {


### PR DESCRIPTION
This is unnecessary complexity for behavior that can be achieved at the next layer up simply by constructing multiple `Switchyard`s.

Finally felt motivated to sort out this old nit.